### PR TITLE
Invalid Return Dates

### DIFF
--- a/Pages/invalidReturnDates.robot
+++ b/Pages/invalidReturnDates.robot
@@ -1,0 +1,46 @@
+*** Settings ***
+Library    SeleniumLibrary
+Resource    ../Pages/basicSearchFlow.robot
+
+*** Variables ***
+${return_dec}                    //select[@id="returning"]/option[text()="December"]
+${schedule_impossible}                          //p[text()="Unfortunately, this schedule is not possible. Please try again."]
+${return_july}                        //select[@id="returning"]/option[text()="July"]
+
+
+
+*** Keywords ***
+User search for flights to Mars that return date is less than 1 year from the departure
+    Wait Until Element Is Visible    ${marsAir_header}    5s
+    Wait Until Element Is Visible    ${welcome_header}
+    Element Should Be Visible        ${departing_label}
+    Click Element                    ${departing_selectBox}
+    Click Element                    ${deapart_july}
+    Element Should Be Visible        ${returning_label}
+    Click Element                    ${returning_selectBox}
+    Click Element                    ${return_dec} 
+    Element Should Be Enabled        ${search_button} 
+    Click Button                     ${search_button}   
+    
+    Wait Until Element Is Visible    ${search_result_header}
+    Element Should Be Visible        ${schedule_impossible}
+    Click Element                    ${back_hyperlink}
+    Wait Until Element Is Visible    ${marsAir_header}    5s
+
+User search for flights to Mars that has same departing and returning date
+    Wait Until Element Is Visible    ${marsAir_header}    5s
+    Wait Until Element Is Visible    ${welcome_header}
+    Element Should Be Visible        ${departing_label}
+    Click Element                    ${departing_selectBox}
+    Click Element                    ${deapart_july}
+    Element Should Be Visible        ${returning_label}
+    Click Element                    ${returning_selectBox}
+    Click Element                    ${return_july}  
+    Element Should Be Enabled        ${search_button} 
+    Click Button                     ${search_button}   
+    
+    Wait Until Element Is Visible    ${search_result_header}
+    Element Should Be Visible        ${schedule_impossible}        # wrong message displayed on the website instead of this
+    Click Element                    ${back_hyperlink}
+    Wait Until Element Is Visible    ${marsAir_header}    5s
+    

--- a/Tests/userstory.robot
+++ b/Tests/userstory.robot
@@ -26,3 +26,17 @@ User search for flights to Mars
    User search for flights to Mars that returns more than next two years from now    
    User search for flights to Mars that returns on the next year
    User search for flights to Mars that returns for for the next two years from now
+
+Invalid Return Dates
+
+#     As a MarsAir Sales Director (Mark)
+#     I want to prevent potential customers from searching for invalid trips
+#     So that they don’t waste time, and book valid ones
+
+#     Acceptance criteria
+#     “Unfortunately, this schedule is not possible. Please try again.” displayed when return date is less than 1 year from the departure.
+   
+   Maximize Browser Window
+   User search for flights to Mars that return date is less than 1 year from the departure
+   # User search for flights to Mars that has same departing and returning date    ## Error ##
+    

--- a/config/Resource.robot
+++ b/config/Resource.robot
@@ -1,2 +1,3 @@
 *** Settings ***
 Resource    ../Pages/basicSearchFlow.robot
+Resource    ../Pages/invalidReturnDates.robot


### PR DESCRIPTION
Invalid Return Dates test cases added

- User search for flights to Mars that has same departing and returning date will be on KIV as different displayed message from the AC